### PR TITLE
fix: create local ref variable in useEffect() to prevent application from crashing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,7 @@ import WidgetEncoding from './example/WidgetEncoding';
 import WidgetNavigation from './example/WidgetNavigation';
 import MouseEvents from './example/MouseEvents';
 import IslandViewer from './example/IslandViewer';
-import "higlass/dist/hglib.css";
+import 'higlass/dist/hglib.css';
 
 // The full list of examples
 const examples = {

--- a/src/example/IslandViewer.jsx
+++ b/src/example/IslandViewer.jsx
@@ -262,8 +262,9 @@ function IslandViewer() {
 
 	useEffect(() => {
 		if (!gosRef.current) return;
-		gosRef.current.api.subscribe('rawData', (type, rawdata) => {
-			const range = gosRef.current.hgApi.api.getLocation(detailID).xDomain
+		const localRef=gosRef.current
+		localRef.api.subscribe('rawData', (type, rawdata) => {
+			const range = localRef.hgApi.api.getLocation(detailID).xDomain
 			if (rawdata.data.length > 0 && rawdata.id === detailID && 'Accnum' in rawdata.data[0]) {
 				const dataInRange = rawdata.data.filter(entry => (entry['Gene start'] > range[0]
                     && entry['Gene start'] < range[1])
@@ -274,9 +275,9 @@ function IslandViewer() {
 			}
 		});
 		return () => {
-			gosRef.current.api.unsubscribe('rawData');
+			localRef.api.unsubscribe('rawData');
 		}
-	}, [gosRef]);
+	}, []);
 	const tableKeys = ['Prediction Method', 'Gene name', 'Accnum', 'Product'];
 	return (
 		<>

--- a/src/example/MouseEvents.jsx
+++ b/src/example/MouseEvents.jsx
@@ -9,14 +9,15 @@ function MouseEvents() {
 
 	useEffect(() => {
 		if(!gosRef.current) return;
+		const localRef=gosRef.current
 
-		gosRef.current.api.subscribe('click', (_, eventData) => {
+		localRef.api.subscribe('click', (_, eventData) => {
 			const { genomicPosition: p } = eventData;
 			setPosition(`${p.chromosome}:${p.position}`)
 			setData(eventData.data);
 		});
 
-		gosRef.current.api.subscribe('rangeSelect', (_, eventData) => {
+		localRef.api.subscribe('rangeSelect', (_, eventData) => {
 			if(!eventData || !eventData.genomicRange) {
 				// range selection cleared
 				setPosition('N/A');
@@ -29,10 +30,10 @@ function MouseEvents() {
 		});
 
 		return () => {
-			gosRef.current.api.unsubscribe('click');
-			gosRef.current.api.unsubscribe('rangeSelect');
+			localRef.api.unsubscribe('click');
+			localRef.api.unsubscribe('rangeSelect');
 		}
-	}, [gosRef]);
+	}, []);
 
 	return (
 		<div>

--- a/src/example/VegaLite.jsx
+++ b/src/example/VegaLite.jsx
@@ -58,9 +58,10 @@ function VegaLiteExample() {
 
 	useEffect(() => {
 		if (!gosRef.current) return;
-		gosRef.current.api.subscribe('rangeSelect', (_, e) => setSelectedData(e.data));
-		return () => gosRef.current.api.unsubscribe('rangeSelect');
-	}, [gosRef]);
+		const localRef=gosRef.current
+		localRef.api.subscribe('rangeSelect', (_, e) => setSelectedData(e.data));
+		return () => localRef.api.unsubscribe('rangeSelect');
+	}, []);
 
 	return (
 		<>


### PR DESCRIPTION
When switching between examples that handle events for refs in a `useEffect()` function the application crashed for me because in this function `gosRef.current` is null in the callback function:
```javascript
return () => gosRef.current.api.unsubscribe('rangeSelect');
```
I don't know why this started to happen after switching to vite. We can prevent this by simply saving the current ref value to a local variable in `useEffect()`, as described [here](https://legacy.reactjs.org/blog/2020/08/10/react-v17-rc.html#potential-issues).