### PR TITLE
feat: add gene spy example

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,8 @@ import WidgetEncoding from './example/WidgetEncoding';
 import WidgetNavigation from './example/WidgetNavigation';
 import MouseEvents from './example/MouseEvents';
 import IslandViewer from './example/IslandViewer';
-import "higlass/dist/hglib.css";
+import 'higlass/dist/hglib.css';
+import GeneSpy from './example/GeneSpy';
 
 // The full list of examples
 const examples = {
@@ -16,6 +17,7 @@ const examples = {
 	'Mouse Events': <MouseEvents/>,
 	'Vega-Lite': <VegaLiteExample/>,
 	IslandViewer: <IslandViewer/>,
+	GeneSpy: <GeneSpy/>
 
 }
 

--- a/src/example/GeneSpy.jsx
+++ b/src/example/GeneSpy.jsx
@@ -1,175 +1,191 @@
-import React from 'react';
+import React, {useCallback, useMemo, useState} from 'react';
 import {GoslingComponent} from 'gosling.js';
 import {Vega} from 'react-vega'
 
 const width = 300;
 const height = 300;
-const goslingSpec = {
-	assembly: [['', 11000]],
-	views: [
-		{
-			alignment: 'overlay',
-			data: {
-				url: 'https://s3.amazonaws.com/gosling-lang.org/data/GeneSpy/gene_spy_example.csv',
-				type: 'csv',
-				genomicFields: ['Gene start', 'Gene end']
-			},
-			color: {
-				field: 'type',
-				type: 'nominal',
-				domain: ['anchor', 'conserved', 'disrupted'],
-				range: ['red', 'gray', 'yellow']
-			},
-			row: {field: 'genome name', type: 'nominal'},
-			tracks: [
-				{
-					dataTransform: [
-						{type: 'filter', field: 'Strand', oneOf: ['+']}
-					],
-					x: {field: 'Gene start', type: 'genomic'},
-					xe: {field: 'Gene end', type: 'genomic'},
-					mark: 'rect'
-				},
-				{
-					dataTransform: [
-						{type: 'filter', field: 'Strand', oneOf: ['+']}
-					],
-					mark: 'rule',
-					strokeWidth: {value: 0},
-					color: {value: 'white'},
-					style: {linePattern: {type: 'triangleRight', size: 10}},
-					x: {field: 'Gene start', type: 'genomic'},
-					xe: {field: 'Gene end', type: 'genomic'}
-				},
-				{
-					dataTransform: [
-						{type: 'filter', field: 'Strand', oneOf: ['-']}
-					],
-					x: {field: 'Gene start', type: 'genomic'},
-					xe: {field: 'Gene end', type: 'genomic'},
-					mark: 'rect',
-					stroke: {value: 'gray'}
-				},
-				{
-					dataTransform: [
-						{type: 'filter', field: 'Strand', oneOf: ['-']}
-					],
-					mark: 'rule',
-					strokeWidth: {value: 0},
-					color: {value: 'white'},
-					style: {linePattern: {type: 'triangleLeft', size: 10}},
-					x: {field: 'Gene start', type: 'genomic'},
-					xe: {field: 'Gene end', type: 'genomic'}
-				}
-			],
-			height: height
-		}
-	]
-};
-const vegaSpec = {
-	$schema: 'https://vega.github.io/schema/vega/v5.json',
-	description: 'An example of Cartesian layouts for a node-link diagram of hierarchical data.',
-	width: width,
-	height: height,
-	padding: 5,
-	data: [
-		{
-			name: 'tree',
-			url: 'https://s3.amazonaws.com/gosling-lang.org/data/GeneSpy/gene_spy_tree.json',
-			transform: [
-				{
-					type: 'stratify',
-					key: 'id',
-					parentKey: 'parent'
-				},
-				{
-					type: 'tree',
-					method: 'cluster',
-					field: {field: 'distance'},
-					sort: {field: 'value', order: 'ascending'},
-					size: [{signal: 'height'}, {signal: 'width'}],
-					separation: false,
-					as: ['y', 'x', 'depth', 'children']
-				},
-				{
-					type: 'formula',
-					expr: 'width * datum.distance',
-					as: 'x'
-				}
-			]
-		},
-		{
-			name: 'leaves',
-			source: 'tree',
-			transform: [
-				{
-					type: 'filter',
-					expr: '!datum.children'
-				}
-			]
-		},
-		{
-			name: 'links',
-			source: 'tree',
-			transform: [
-				{type: 'treelinks'},
-				{
-					type: 'linkpath',
-					orient: 'horizontal',
-					shape: 'orthogonal'
-				}
-			]
-		}
-	],
-	marks: [
-		{
-			type: 'path',
-			from: {data: 'links'},
-			encode: {
-				update: {
-					path: {field: 'path'},
-					stroke: {value: '#ccc'}
-				}
-			}
-		},
-		{
-			type: 'rule',
-			from: {data: 'leaves'},
-			encode: {
-				update: {
-					x: {field:'x'},
-					y: {field: 'y'},
-					x2: {value:width},
-					y2: {field: 'y'},
-					stroke: {value: '#eee'},
-				}
-			}
-		},
-		{
-			type: 'text',
-			from: {data: 'leaves'},
-			encode: {
-				enter: {
-					text: {field: 'name'},
-					fontSize: {value: 9},
-					baseline: {value: 'middle'}
-				},
-				update: {
-					x: {value: width},
-					y: {field: 'y'},
-					dx: {signal: 'datum.children ? -7 : 7'},
-					align: 'left'
-				}
-			}
-		}
-	]
-};
 
 function GeneSpy() {
+	// track order to link leaves of vega tree to tracks in gosling
+	const [trackOrder, setTrackOrder]=useState([])
+	const [maxDist,setMaxDist]=useState(1)
+	const onNewView = useCallback(view=>{
+		let leaves=view.data('leaves').slice();
+		leaves.sort((a,b)=>a.x-b.x);
+		setTrackOrder(leaves.map(leaf=>leaf.id))
+		setMaxDist(Math.max(...leaves.map(d=>d.distance)))
+	},[])
+	const goslingSpec=useMemo(()=>{
+		return({
+			title: 'GeneSpy + iTol',
+			subtitle: 'Genomic neighborhood visualization with aligned phylogenetic tree',
+			description: 'Idea: https://doi.org/10.1093/bioinformatics/bty459',
+			assembly: [['', 11000]],
+			static: true,
+			views: [
+				{
+					alignment: 'overlay',
+					data: {
+						url: 'https://s3.amazonaws.com/gosling-lang.org/data/GeneSpy/gene_spy_example.csv',
+						type: 'csv',
+						genomicFields: ['Gene start', 'Gene end']
+					},
+					dataTransform: [
+						{type: 'genomicLength', startField: 'Gene start', endField: 'Gene end', newField:'Gene length'}
+					],
+					color: {
+						field: 'type',
+						type: 'nominal',
+						domain: ['anchor', 'conserved', 'disrupted'],
+						range: ['red', 'gray', 'yellow']
+					},
+					row: {field: 'Accession', type: 'nominal',domain: trackOrder},
+					tracks: [
+						{
+							dataTransform: [
+								{type: 'filter', field: 'Strand', oneOf: ['+']}
+							],
+							x: {field: 'Gene start', type: 'genomic'},
+							xe: {field: 'Gene end', type: 'genomic'},
+							mark: 'rect',
+							size: {value: 2}
+						},
+						{
+							dataTransform: [
+								{type: 'filter', field: 'Strand', oneOf: ['+']}
+							],
+							mark: 'triangleRight',
+							style: {align: 'right'},
+							size: {field:'Gene length'},
+							x: {field: 'Gene end', type: 'genomic'},
+						},
+						{
+							dataTransform: [
+								{type: 'filter', field: 'Strand', oneOf: ['-']}
+							],
+							x: {field: 'Gene start', type: 'genomic'},
+							xe: {field: 'Gene end', type: 'genomic'},
+							mark: 'rect',
+							size: {value: 2},
+							stroke: {value: 'gray'}
+						},
+						{
+							dataTransform: [
+								{type: 'filter', field: 'Strand', oneOf: ['-']}
+							],
+							mark: 'triangleLeft',
+							style: {align: 'left'},
+							x: {field: 'Gene start', type: 'genomic'},
+						}
+					],
+					height: height
+				}
+			]
+		})
+	},[trackOrder])
+	const vegaSpec = useMemo(()=>{
+		return({$schema: 'https://vega.github.io/schema/vega/v5.json',
+			description: 'An example of Cartesian layouts for a node-link diagram of hierarchical data.',
+			width: width,
+			height: height,
+			padding: 0,
+			data: [
+				{
+					name: 'tree',
+					url: 'https://s3.amazonaws.com/gosling-lang.org/data/GeneSpy/gene_spy_tree.json',
+					transform: [
+						{
+							type: 'stratify',
+							key: 'id',
+							parentKey: 'parent'
+						},
+						{
+							type: 'tree',
+							method: 'cluster',
+							field: {field: 'distance'},
+							sort: {field: 'value', order: 'ascending'},
+							size: [{signal: 'height'}, {signal: 'width'}],
+							separation: false,
+							as: ['y', 'x', 'depth', 'children']
+						},
+						{
+							type: 'formula',
+							expr: 'width  * (datum.distance/'+maxDist+')',
+							as: 'x'
+						}
+					]
+				},
+				{
+					name: 'leaves',
+					source: 'tree',
+					transform: [
+						{
+							type: 'filter',
+							expr: '!datum.children'
+						}
+					]
+				},
+				{
+					name: 'links',
+					source: 'tree',
+					transform: [
+						{type: 'treelinks'},
+						{
+							type: 'linkpath',
+							orient: 'horizontal',
+							shape: 'orthogonal'
+						}
+					]
+				}
+			],
+			marks: [
+				{
+					type: 'path',
+					from: {data: 'links'},
+					encode: {
+						update: {
+							path: {field: 'path'},
+							stroke: {value: '#000'}
+						}
+					}
+				},
+				{
+					type: 'rule',
+					from: {data: 'leaves'},
+					encode: {
+						update: {
+							x: {field: 'x'},
+							y: {field: 'y'},
+							x2: {value: width},
+							y2: {field: 'y'},
+							stroke: {value: '#eee'},
+						}
+					}
+				},
+				{
+					type: 'text',
+					from: {data: 'leaves'},
+					encode: {
+						enter: {
+							text: {field: 'name'},
+							fontSize: {value: 9},
+							baseline: {value: 'middle'}
+						},
+						update: {
+							x: {value: width},
+							y: {field: 'y'},
+							dx: {signal: 'datum.children ? -7 : 7'},
+							align: 'left'
+						}
+					}
+				}
+			]
+		})
+	},[maxDist])
 	return (
 		<>
 			<div style={{display: 'inline-block'}}>
-				<Vega spec={vegaSpec}/>
+				<Vega spec={vegaSpec} onNewView={onNewView} actions={false}/>
 			</div>
 			<div style={{display: 'inline-block'}}>
 				<GoslingComponent

--- a/src/example/GeneSpy.jsx
+++ b/src/example/GeneSpy.jsx
@@ -45,29 +45,11 @@ function GeneSpy() {
 							dataTransform: [
 								{type: 'filter', field: 'Strand', oneOf: ['+']}
 							],
-							x: {field: 'Gene start', type: 'genomic'},
-							xe: {field: 'Gene end', type: 'genomic'},
-							mark: 'rect',
-							size: {value: 2}
-						},
-						{
-							dataTransform: [
-								{type: 'filter', field: 'Strand', oneOf: ['+']}
-							],
 							mark: 'triangleRight',
 							style: {align: 'right'},
 							size: {field:'Gene length'},
 							x: {field: 'Gene end', type: 'genomic'},
-						},
-						{
-							dataTransform: [
-								{type: 'filter', field: 'Strand', oneOf: ['-']}
-							],
-							x: {field: 'Gene start', type: 'genomic'},
-							xe: {field: 'Gene end', type: 'genomic'},
-							mark: 'rect',
-							size: {value: 2},
-							stroke: {value: 'gray'}
+							xe: {field: 'Gene start', type: 'genomic'}
 						},
 						{
 							dataTransform: [
@@ -76,6 +58,7 @@ function GeneSpy() {
 							mark: 'triangleLeft',
 							style: {align: 'left'},
 							x: {field: 'Gene start', type: 'genomic'},
+							xe: {field: 'Gene end', type: 'genomic'}
 						}
 					],
 					height: height

--- a/src/example/GeneSpy.jsx
+++ b/src/example/GeneSpy.jsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import {GoslingComponent} from 'gosling.js';
+import {Vega} from 'react-vega'
+
+const width = 300;
+const height = 300;
+const goslingSpec = {
+	assembly: [['', 11000]],
+	views: [
+		{
+			alignment: 'overlay',
+			data: {
+				url: 'https://s3.amazonaws.com/gosling-lang.org/data/GeneSpy/gene_spy_example.csv',
+				type: 'csv',
+				genomicFields: ['Gene start', 'Gene end']
+			},
+			color: {
+				field: 'type',
+				type: 'nominal',
+				domain: ['anchor', 'conserved', 'disrupted'],
+				range: ['red', 'gray', 'yellow']
+			},
+			row: {field: 'genome name', type: 'nominal'},
+			tracks: [
+				{
+					dataTransform: [
+						{type: 'filter', field: 'Strand', oneOf: ['+']}
+					],
+					x: {field: 'Gene start', type: 'genomic'},
+					xe: {field: 'Gene end', type: 'genomic'},
+					mark: 'rect'
+				},
+				{
+					dataTransform: [
+						{type: 'filter', field: 'Strand', oneOf: ['+']}
+					],
+					mark: 'rule',
+					strokeWidth: {value: 0},
+					color: {value: 'white'},
+					style: {linePattern: {type: 'triangleRight', size: 10}},
+					x: {field: 'Gene start', type: 'genomic'},
+					xe: {field: 'Gene end', type: 'genomic'}
+				},
+				{
+					dataTransform: [
+						{type: 'filter', field: 'Strand', oneOf: ['-']}
+					],
+					x: {field: 'Gene start', type: 'genomic'},
+					xe: {field: 'Gene end', type: 'genomic'},
+					mark: 'rect',
+					stroke: {value: 'gray'}
+				},
+				{
+					dataTransform: [
+						{type: 'filter', field: 'Strand', oneOf: ['-']}
+					],
+					mark: 'rule',
+					strokeWidth: {value: 0},
+					color: {value: 'white'},
+					style: {linePattern: {type: 'triangleLeft', size: 10}},
+					x: {field: 'Gene start', type: 'genomic'},
+					xe: {field: 'Gene end', type: 'genomic'}
+				}
+			],
+			height: height
+		}
+	]
+};
+const vegaSpec = {
+	$schema: 'https://vega.github.io/schema/vega/v5.json',
+	description: 'An example of Cartesian layouts for a node-link diagram of hierarchical data.',
+	width: width,
+	height: height,
+	padding: 5,
+	data: [
+		{
+			name: 'tree',
+			url: 'https://s3.amazonaws.com/gosling-lang.org/data/GeneSpy/gene_spy_tree.json',
+			transform: [
+				{
+					type: 'stratify',
+					key: 'id',
+					parentKey: 'parent'
+				},
+				{
+					type: 'tree',
+					method: 'cluster',
+					field: {field: 'distance'},
+					sort: {field: 'value', order: 'ascending'},
+					size: [{signal: 'height'}, {signal: 'width'}],
+					separation: false,
+					as: ['y', 'x', 'depth', 'children']
+				},
+				{
+					type: 'formula',
+					expr: 'width * datum.distance',
+					as: 'x'
+				}
+			]
+		},
+		{
+			name: 'leaves',
+			source: 'tree',
+			transform: [
+				{
+					type: 'filter',
+					expr: '!datum.children'
+				}
+			]
+		},
+		{
+			name: 'links',
+			source: 'tree',
+			transform: [
+				{type: 'treelinks'},
+				{
+					type: 'linkpath',
+					orient: 'horizontal',
+					shape: 'orthogonal'
+				}
+			]
+		}
+	],
+	marks: [
+		{
+			type: 'path',
+			from: {data: 'links'},
+			encode: {
+				update: {
+					path: {field: 'path'},
+					stroke: {value: '#ccc'}
+				}
+			}
+		},
+		{
+			type: 'rule',
+			from: {data: 'leaves'},
+			encode: {
+				update: {
+					x: {field:'x'},
+					y: {field: 'y'},
+					x2: {value:width},
+					y2: {field: 'y'},
+					stroke: {value: '#eee'},
+				}
+			}
+		},
+		{
+			type: 'text',
+			from: {data: 'leaves'},
+			encode: {
+				enter: {
+					text: {field: 'name'},
+					fontSize: {value: 9},
+					baseline: {value: 'middle'}
+				},
+				update: {
+					x: {value: width},
+					y: {field: 'y'},
+					dx: {signal: 'datum.children ? -7 : 7'},
+					align: 'left'
+				}
+			}
+		}
+	]
+};
+
+function GeneSpy() {
+	return (
+		<>
+			<div style={{display: 'inline-block'}}>
+				<Vega spec={vegaSpec}/>
+			</div>
+			<div style={{display: 'inline-block'}}>
+				<GoslingComponent
+					padding={0}
+					spec={goslingSpec}
+					experimental={{reactive: true}}
+				/>
+			</div>
+		</>
+	);
+}
+
+export default GeneSpy;

--- a/src/example/GeneSpy.jsx
+++ b/src/example/GeneSpy.jsx
@@ -48,8 +48,8 @@ function GeneSpy() {
 							mark: 'triangleRight',
 							style: {align: 'right'},
 							size: {field:'Gene length'},
-							x: {field: 'Gene end', type: 'genomic'},
-							xe: {field: 'Gene start', type: 'genomic'}
+							x: {field: 'Gene start', type: 'genomic'},
+							xe: {field: 'Gene end', type: 'genomic'}
 						},
 						{
 							dataTransform: [


### PR DESCRIPTION
This example demonstrates how to combine a phylogenetic tree created with vega with a gosling visualization. The tree layout is created by vega and the x values of the nodes/links are transformed according to the distances in the phylogenetic tree. An `onNewView` event listener on the  vega component is used to get the order of the leaves in the tree to apply them as the order of the tracks in the gosling component.

<img width="1038" alt="image" src="https://github.com/gosling-lang/gosling-react-example/assets/15909854/7d8d1b4c-243c-4a12-802b-1c21a54efb82">

The example is not exactly the same as in the [original publication](https://doi.org/10.1093/bioinformatics/bty459), but I still think it is a valuable addition.
- It contains fewer sequences than the original example (because I could not get the identifiers for all of them)
- The tree is slightly different because I recalculated it with a different method (mafft)
- The color encoding for the non-conserved genes is not detailed 

@sehilyi is there a way to hide the axis while having a custom assembly? I know there is `assembly: 'unknown' `and `assembly: [['chromosome',10000]]` but I am looking for a combination of both.
